### PR TITLE
Fix debug argument placement

### DIFF
--- a/python/test_app.py
+++ b/python/test_app.py
@@ -1339,7 +1339,7 @@ class NitroDockerContainer(DockerContainer):
         request.converter_options.push_converted_image = not self.allow_docker_push_failure
 
         if os.getenv('ENCLAVEOS_DEBUG', "") == "debug" or os.getenv('FLAVOR', "") == "debug":
-            request.nitro_enclaves_options.debug = True
+            request.converter_options.debug = True
 
         if self.entrypoint:
             request.converter_options.entry_point = self.entrypoint


### PR DESCRIPTION
Corrects the logic that sets `debug` (https://github.com/fortanix/salmiac/blob/f420ca867761a0ad1b12249f90cab814156d3f15/api-model/src/converter.rs#L153) value in Salmiac conversion request. Current logic tries to set field `debug` in https://github.com/fortanix/salmiac/blob/f420ca867761a0ad1b12249f90cab814156d3f15/api-model/src/converter.rs#L196 which doesn't have a field with such name. In particular this change fixes `TestMysql` application test.